### PR TITLE
Feature/turn off normalization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ default option in the Astrometry object.
 - All fits have the domains normalized for numerical stability.
 Changes to how the user interacts with HTOF:
 - `central_epoch_fmt=` In htof.main.Astrometry is now `format=` and should 
-  follow the same convention as astropy.time.Time. E.g. `format='jd'` or `format='fracyear'`
+  follow the same convention as astropy.time.Time. E.g. `format='jd'` or `format='decimalyear'`
   The returned proper motions from Astrometry.fit will have time units consistent
   with `format`. E.g. setting `format='fracyear'` would return proper motions with
   units of mas/yr (and accelerations with mas/year^2 etc..).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+0.2.3 (2019-12-09)
+------------------
+- Users can now select normed=False in AstrometricFitter and Astrometry, if they wish to disable
+the internal normalization which enhances numerical stability. Most users would want to leave
+normed=True.
+
 0.2.2 (2019-12-09)
 ------------------
 - For Hipparcos 1, users can now select a data_choice of 'MERGED' which will

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ htof
 ===============
 
 This repo contains htof, the package for parsing intermediate data from the Gaia and
-Hipparcos Satellites, and reproducing five, seven, and nine parameter fits to their astrometry.
+Hipparcos satellites, and reproducing five, seven, and nine (or higher) parameter fits to their astrometry.
 
 .. image:: https://coveralls.io/repos/github/gmbrandt/HTOF/badge.svg?branch=master
     :target: https://coveralls.io/github/gmbrandt/HTOF?branch=master
@@ -73,6 +73,7 @@ then the last two parameters would be one-sixth the jerk in right ascension and 
 HTOF allows fits of arbitrarily high degree. E.g. setting fit_degree=5 would give a 13 parameter
 fit (if using parallax as well). HTOF normalizes all epochs and times
 from -1 to 1, so the linear algebra performed by HTOF is all very numerically stable.
+This normalization can be disabled via the boolean keyword ``normed``, but one should be weary of turning this off.
 
 If you want to specify a central epoch, you can do so with:
 
@@ -84,7 +85,8 @@ If you want to specify a central epoch, you can do so with:
     ra0, dec0, mu_ra, mu_dec = astro.fit(ra_vs_epoch, dec_vs_epoch)
 
 The format of the central epochs must be specified along with the central epochs. The best fit sky path in right ascension would then be
-:code:`ra0 + mu_ra * (epochs - centra_epoch_ra)`.
+:code:`ra0 + mu_ra * (epochs - centra_epoch_ra)`. The central epoch matters for numerical stability *only* when
+``normed=False`` is set upon instantiation of ``Astrometry``.
 
 Specifying :code:`GaiaDR2` will clip any intermediate data to fall within the observation
 dates which mark the period covered by data release 2. Use :code:`Gaia` if you want any

--- a/htof/fit.py
+++ b/htof/fit.py
@@ -15,20 +15,15 @@ class AstrometricFitter(object):
                                         for each epoch
     :param epoch_times: 1D array
                         array with each epoch. If these are years, then the returned proper motions will
-                         be in Angle/year as well.
+                         be in Angle/year as well. The unit of epoch_times should be the same as central_epoch_ra
+                         and central_epoch_dec.
     :param parallactic_pertubations: dict
            {'ra_plx': array-like, 'dec_plx': array-like}
            the pertubations from parallactic motion. e.g. central_ra + parallactic_pertubations['ra_plx']
            would give the skypath (in RA) of the object throughout the time observed, from parallax alone.
-    :param parameters: int.
-                       number of parameters in the fit. Options are 4, 5, 7, and 9.
-                       4 is just offset and proper motion, 5 includes parallax, 7 and 9 include accelerations and jerks.
-    The pertubations due to parallactic motion alone with unit parallax. Where parallactic_pertubations[0], and
-    parallactic_pertubations[1] are the pertubations for right ascension and declination respectively.
-    For each component this should be the quantity which is linear in parallax angle, i.e.:
-    Parallax_motion_ra - central_ra.
-    The units of this parallactic motion should be exactly the same as the ra's and dec's which you will fit
-    later on.
+    :param fit_degree: int.
+                       number of degrees in polynomial fit. fit_degree=1 with parallax would be a five parameter
+                       fit. fit_degree=2 with parallax would be a 7 parameter fit.
     """
     def __init__(self, inverse_covariance_matrices=None, epoch_times=None,
                  astrometric_chi_squared_matrices=None, astrometric_solution_vector_components=None,

--- a/htof/fit.py
+++ b/htof/fit.py
@@ -112,6 +112,7 @@ class AstrometricFitter(object):
 
     def _init_epochs(self):
         if not self.normed:
+            # comment so that unit test registers.
             return self.epoch_times - self.central_epoch_ra, self.epoch_times - self.central_epoch_dec
         if self.normed:
             normed_epochs = normalize(self.epoch_times, [np.max(self.epoch_times), np.min(self.epoch_times)])

--- a/htof/main.py
+++ b/htof/main.py
@@ -23,7 +23,7 @@ class Astrometry(object):
 
     def __init__(self, data_choice, star_id, intermediate_data_directory, fitter=None, data=None,
                  central_epoch_ra=0, central_epoch_dec=0, format='jd', fit_degree=1,
-                 use_parallax=False, central_ra=None, central_dec=None):
+                 use_parallax=False, central_ra=None, central_dec=None, normed=True):
 
         if data is None:
             DataParser = self.parsers[data_choice.lower()]
@@ -52,7 +52,8 @@ class Astrometry(object):
                                        central_epoch_ra=Time(central_epoch_ra, format=format).value,
                                        fit_degree=fit_degree,
                                        use_parallax=use_parallax,
-                                       parallactic_pertubations=parallactic_pertubations)
+                                       parallactic_pertubations=parallactic_pertubations,
+                                       normed=normed)
         self.data = data
         self.fitter = fitter
 

--- a/htof/test/test_fit.py
+++ b/htof/test/test_fit.py
@@ -15,6 +15,8 @@ class TestAstrometricFitter:
                                    fit_degree=1, use_parallax=False, normed=False)
         assert np.allclose(fitter.dec_epochs, [-0.5, 0.5, 1.5])
         assert np.allclose(fitter.ra_epochs, [0, 1, 2])
+        # this poor-form test below is specifically so that the coverage report hits it (it does not register the above)
+        assert np.allclose(fitter._init_epochs()[0], [0, 1, 2])
 
     def test_init_epochs(self):
         fitter = AstrometricFitter(astrometric_solution_vector_components=[], central_epoch_dec=1.5, central_epoch_ra=1,

--- a/htof/test/test_fit.py
+++ b/htof/test/test_fit.py
@@ -9,12 +9,14 @@ from htof.sky_path import parallactic_motion
 
 
 class TestAstrometricFitter:
-    def test_init_epochs(self):
+    def test_init_epochs_no_norm(self):
         fitter = AstrometricFitter(astrometric_solution_vector_components=[], central_epoch_dec=1.5, central_epoch_ra=1,
                                    epoch_times=np.array([1, 2, 3]), astrometric_chi_squared_matrices=[],
                                    fit_degree=1, use_parallax=False, normed=False)
         assert np.allclose(fitter.dec_epochs, [-0.5, 0.5, 1.5])
         assert np.allclose(fitter.ra_epochs, [0, 1, 2])
+
+    def test_init_epochs(self):
         fitter = AstrometricFitter(astrometric_solution_vector_components=[], central_epoch_dec=1.5, central_epoch_ra=1,
                                    epoch_times=np.array([1, 2, 3]), astrometric_chi_squared_matrices=[],
                                    fit_degree=1, use_parallax=False, normed=True)

--- a/htof/test/test_fit.py
+++ b/htof/test/test_fit.py
@@ -15,8 +15,6 @@ class TestAstrometricFitter:
                                    fit_degree=1, use_parallax=False, normed=False)
         assert np.allclose(fitter.dec_epochs, [-0.5, 0.5, 1.5])
         assert np.allclose(fitter.ra_epochs, [0, 1, 2])
-        # this poor-form test below is specifically so that the coverage report hits it (it does not register the above)
-        assert np.allclose(fitter._init_epochs()[0], [0, 1, 2])
 
     def test_init_epochs(self):
         fitter = AstrometricFitter(astrometric_solution_vector_components=[], central_epoch_dec=1.5, central_epoch_ra=1,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(name='htof',
       author=['G. Mirek Brandt, Daniel Michalik'],
-      version='0.2.2',
+      version='0.2.3',
       python_requires='>=3.5',
       packages=find_packages(),
       package_dir={'htof': 'htof'},


### PR DESCRIPTION
This adds a `normed` keyword argument to htof.main.Astrometry and htof.fit.AstrometricFitter. E.g. htof.main.Astrometry(..., normed=False). normed=True is default. Setting normed=False disables the internal normalization (setting normed=False potentially makes the linear algebra unstable). normed=False is used in github.com/t-brandt/orbit3d because the internal linear algebra matrices that HTOF computes are used in that code.