### PR TITLE
Fix/depreciated calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-0.3.4 (2021-04-19)
+0.3.5 (2021-04-19)
 ------------------
 - Fixed improper syntax calls to panda etc. so that warnings are silence in python 3.8 and beyond.
 - We have a deprecated call that cannot be fixed, and appears to be

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,11 @@
-0.3.4 (2020-02-24)
+0.3.4 (2021-04-19)
+------------------
+- Fixed improper syntax calls to panda etc. so that warnings are silence in python 3.8 and beyond.
+- We have a deprecated call that cannot be fixed, and appears to be
+  located upstream in ipython https://github.com/ipython/ipykernel/issues/560
+- Removed normed option for fitting.
+
+0.3.4 (2021-02-24)
 ------------------
 - Removed the numba speed up from FastFitter. Will add it back in if there is ever a need for a fast fitter.
 

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ Hipparcos satellites, and reproducing five, seven, and nine (or higher) paramete
 .. image:: https://coveralls.io/repos/github/gmbrandt/HTOF/badge.svg?branch=master
     :target: https://coveralls.io/github/gmbrandt/HTOF?branch=master
 
-.. image:: https://travis-ci.org/gmbrandt/HTOF.svg?branch=master
-    :target: https://travis-ci.org/gmbrandt/HTOF
+.. image:: https://travis-ci.com/gmbrandt/HTOF.svg?branch=master
+    :target: https://travis-ci.com/gmbrandt/HTOF
 
 Parallax is handled by the :code:`sky_path` module which was written by Anthony Brown
 as a part of his astrometric-sky-path package: https://github.com/agabrown/astrometric-sky-path/

--- a/htof/fit.py
+++ b/htof/fit.py
@@ -77,16 +77,16 @@ class AstrometricFitter(object):
         :return: float. The reference epoch which makes the positional and proper motion covariance zero
         in the coordinate specified (either ra or dec).
         """
-        if coordinate is not 'ra' and coordinate is not 'dec':
+        if coordinate != 'ra' and coordinate != 'dec':
             raise ValueError('coordinate kwarg must be either ra or dec')
         # get the row (i) and column (j) that we are going to try and minimize in the covariance matrix
         row_coord, col_coord = {}, {}
-        if coordinate is 'ra':
+        if coordinate =='ra':
             row_coord['pm_pos_covariance'] = 1
             col_coord['pm_pos_covariance'] = 3
             row_coord['pm_variance'] = 3
             col_coord['pm_variance'] = 3
-        if coordinate is 'dec':
+        if coordinate == 'dec':
             row_coord['pm_pos_covariance'] = 2
             col_coord['pm_pos_covariance'] = 4
             row_coord['pm_variance'] = 4

--- a/htof/fit.py
+++ b/htof/fit.py
@@ -29,9 +29,7 @@ class AstrometricFitter(object):
     def __init__(self, inverse_covariance_matrices=None, epoch_times=None,
                  astrometric_chi_squared_matrices=None, astrometric_solution_vector_components=None,
                  parallactic_pertubations=None, fit_degree=1, use_parallax=False,
-                 central_epoch_ra=0, central_epoch_dec=0, normed=False):
-        if normed:
-            self._on_normed()
+                 central_epoch_ra=0, central_epoch_dec=0):
         if parallactic_pertubations is None:
             parallactic_pertubations = {'ra_plx': np.zeros_like(epoch_times),
                                         'dec_plx': np.zeros_like(epoch_times)}
@@ -42,7 +40,6 @@ class AstrometricFitter(object):
         self.fit_degree = fit_degree
         self.central_epoch_dec = central_epoch_dec
         self.central_epoch_ra = central_epoch_ra
-        self.normed = normed
         self.ra_epochs, self.dec_epochs = self._init_epochs()
 
         if astrometric_solution_vector_components is None:
@@ -118,11 +115,6 @@ class AstrometricFitter(object):
         cov_matrix = np.linalg.pinv(icov_matrix, hermitian=True)
         return cov_matrix
 
-    def _on_normed(self):
-        warnings.warn('the normed fitting option (normed=True) will be removed in a future release.'
-                      ' Do not use normed=True because it will cause the returned fit errors to be incorrect.',
-                      PendingDeprecationWarning)
-
     def fit_line(self, ra_vs_epoch, dec_vs_epoch, return_all=False):
         """
         :param ra_vs_epoch: 1d array of right ascension, ordered the same as the covariance matrices and epochs.
@@ -143,16 +135,6 @@ class AstrometricFitter(object):
                              self.ra_epochs, self.dec_epochs,
                              self.inverse_covariance_matrices, **self.parallactic_pertubations,
                              use_parallax=self.use_parallax)
-        if self.normed:
-            # transforming out of normalized coordinates.
-            c_ra, c_dec = self.central_epoch_ra, self.central_epoch_dec
-            t = self.epoch_times
-            solution = transform_coefficients_to_unnormalized_domain(solution, t.min() - c_ra, t.max() - c_ra,
-                                                                     t.min() - c_dec, t.max() - c_dec, self.use_parallax)
-            # TODO : One should not transform the errors like the solution vector.
-            # TODO: easy but bulky way: reconstruct the chi^2 matrix here.
-            errors = transform_coefficients_to_unnormalized_domain(errors, t.min() - c_ra, t.max() - c_ra,
-                                                                   t.min() - c_dec, t.max() - c_dec, self.use_parallax)
         return solution if not return_all else (solution, errors, chisq)
 
     def _chi2_vector(self, ra_vs_epoch, dec_vs_epoch):
@@ -197,12 +179,7 @@ class AstrometricFitter(object):
         return np.sum(astrometric_chi_squared_matrices, axis=0), astrometric_chi_squared_matrices
 
     def _init_epochs(self):
-        if not self.normed:
-            # comment so that unit test registers.
-            return np.array(self.epoch_times) - self.central_epoch_ra, np.array(self.epoch_times) - self.central_epoch_dec
-        if self.normed:
-            normed_epochs = normalize(self.epoch_times, [np.max(self.epoch_times), np.min(self.epoch_times)])
-            return 1.*normed_epochs, 1.*normed_epochs
+        return np.array(self.epoch_times) - self.central_epoch_ra, np.array(self.epoch_times) - self.central_epoch_dec
 
 
 class AstrometricFastFitter(AstrometricFitter):
@@ -220,9 +197,6 @@ class AstrometricFastFitter(AstrometricFitter):
         """
         return fast_fit_line(self._chi2_matrix, self.astrometric_solution_vector_components['ra'],
                              self.astrometric_solution_vector_components['dec'], ra_vs_epoch, dec_vs_epoch)
-
-    def _on_normed(self):
-        raise NotImplementedError('AstrometricFastFitter cannot implement the normed=True fit feature')
 
 
 #@jit(nopython=True)

--- a/htof/main.py
+++ b/htof/main.py
@@ -23,8 +23,12 @@ class Astrometry(object):
 
     def __init__(self, data_choice, star_id, intermediate_data_directory, fitter=None, data=None,
                  central_epoch_ra=0, central_epoch_dec=0, format='jd', fit_degree=1,
-                 use_parallax=False, central_ra=None, central_dec=None, normed=False):
+                 use_parallax=False, central_ra=None, central_dec=None, **kwargs):
 
+        if 'normed' in kwargs:
+            warnings.warn('normed keyword argument will be removed in the next minor version'
+                          'of htof. Please delete normed=False wherever it is used. Note that'
+                          'normed=True has no affect.', PendingDeprecationWarning)
         if data is None:
             DataParser = self.parsers[data_choice.lower()]
             data = DataParser()
@@ -51,8 +55,7 @@ class Astrometry(object):
                                        central_epoch_ra=Time(central_epoch_ra, format=format).value,
                                        fit_degree=fit_degree,
                                        use_parallax=use_parallax,
-                                       parallactic_pertubations=parallactic_pertubations,
-                                       normed=normed)
+                                       parallactic_pertubations=parallactic_pertubations)
         self.data = data
         self.fitter = fitter
 

--- a/htof/main.py
+++ b/htof/main.py
@@ -26,9 +26,9 @@ class Astrometry(object):
                  use_parallax=False, central_ra=None, central_dec=None, **kwargs):
 
         if 'normed' in kwargs:
-            warnings.warn('normed keyword argument will be removed in the next minor version'
-                          'of htof. Please delete normed=False wherever it is used. Note that'
-                          'normed=True has no affect.', PendingDeprecationWarning)
+            warnings.warn('normed keyword argument is Depreciated and will be removed in the next minor version ' 
+                          'of htof. Please delete normed=False wherever it is used. Note that neither '
+                          'normed=True nor False have any affect as of 0.3.5.', DeprecationWarning)
         if data is None:
             DataParser = self.parsers[data_choice.lower()]
             data = DataParser()

--- a/htof/test/test_data_utils.py
+++ b/htof/test/test_data_utils.py
@@ -22,7 +22,7 @@ def test_merge_consortia_equal_on_flipped_rows():
     data2 = pd.DataFrame([[133, 'N', -0.9051, -0.4252,  0.6263, 1.1265,  0.5291, -1.18, 1.59, 0.393],
                          [133, 'F', -0.9053, -0.4248,  0.6270,  1.1264,  0.5285, -2.50,  2.21,  0.393]],
                         columns=['A1', 'IA2', 'IA3', 'IA4', 'IA5', 'IA6', 'IA7', 'IA8', 'IA9', 'IA10'])
-    pd.testing.assert_frame_equal(merge_consortia(data2), merge_consortia(data1), check_less_precise=2)
+    pd.testing.assert_frame_equal(merge_consortia(data2), merge_consortia(data1))
 
 
 def test_safe_concatenate():

--- a/htof/test/test_fit.py
+++ b/htof/test/test_fit.py
@@ -11,6 +11,7 @@ from htof.sky_path import parallactic_motion
 
 np.random.seed(seed=1234111)
 
+
 class TestAstrometricFitter:
     def test_init_epochs(self):
         fitter = AstrometricFitter(astrometric_solution_vector_components=[], central_epoch_dec=1.5, central_epoch_ra=1,

--- a/htof/test/test_fit.py
+++ b/htof/test/test_fit.py
@@ -9,6 +9,7 @@ from htof.fit import unpack_elements_of_matrix, AstrometricFitter, normalize, As
 from htof.utils.fit_utils import ra_sol_vec, dec_sol_vec, chi2_matrix, transform_coefficients_to_unnormalized_domain
 from htof.sky_path import parallactic_motion
 
+np.random.seed(seed=1234111)
 
 class TestAstrometricFitter:
     def test_init_epochs(self):
@@ -89,20 +90,8 @@ class TestAstrometricFitter:
         assert np.isclose(0, chisq, atol=1e-7)
 
     def test_fitting_with_nonzero_central_epoch(self):
-        ra_cnt = np.random.randint(1, 100)
-        dec_cnt = np.random.randint(1, 100)
-        astrometric_data = generate_astrometric_data()
-        expected_vec = astrometric_data['linear_solution']
-        expected_vec[0] += ra_cnt * expected_vec[2]  # r0 = ra_central_time * mu_ra
-        expected_vec[1] += dec_cnt * expected_vec[3]  # dec0 = dec_central_time * mu_dec
-        fitter = AstrometricFitter(inverse_covariance_matrices=astrometric_data['inverse_covariance_matrix'],
-                              epoch_times=astrometric_data['epoch_delta_t'],
-                              central_epoch_dec=dec_cnt, central_epoch_ra=ra_cnt)
-        assert np.allclose(fitter.fit_line(astrometric_data['ra'], astrometric_data['dec']), expected_vec)
-
-    def test_fitting_with_normalization(self):
-        ra_cnt = np.random.randint(1, 100)
-        dec_cnt = np.random.randint(1, 100)
+        ra_cnt = np.random.randint(1, 5)
+        dec_cnt = np.random.randint(1, 5)
         astrometric_data = generate_astrometric_data()
         expected_vec = astrometric_data['linear_solution']
         expected_vec[0] += ra_cnt * expected_vec[2]  # r0 = ra_central_time * mu_ra

--- a/htof/test/test_main.py
+++ b/htof/test/test_main.py
@@ -207,7 +207,7 @@ def test_optimal_central_epochs_forHip1_hip27321():
     # generate fitter and parse intermediate data
     astro = Astrometry('Hip1', '27321', 'htof/test/data_for_tests/Hip1', central_epoch_ra=1991.25,
                        central_epoch_dec=1991.25, format='jyear', fit_degree=1, use_parallax=True,
-                       central_ra=cntr_ra, central_dec=cntr_dec)
+                       central_ra=cntr_ra, central_dec=cntr_dec, normed=False)
     central_epoch = astro.optimal_central_epochs()
     central_epoch_ra, central_epoch_dec = central_epoch['ra'], central_epoch['dec']
     #print(central_epoch_ra, central_epoch_dec)

--- a/htof/test/test_main.py
+++ b/htof/test/test_main.py
@@ -94,7 +94,7 @@ def test_Hip1_fit_to_hip27321():
     # generate fitter and parse intermediate data
     astro = Astrometry('Hip1', '27321', 'htof/test/data_for_tests/Hip1', central_epoch_ra=1991.25,
                        central_epoch_dec=1991.25, format='jyear', fit_degree=1, use_parallax=True,
-                       central_ra=cntr_ra, central_dec=cntr_dec, normed=False)
+                       central_ra=cntr_ra, central_dec=cntr_dec)
     chisq = np.sum(astro.data.residuals ** 2 / astro.data.along_scan_errs ** 2)
     # generate ra and dec for each observation.
     year_epochs = Time(astro.data.julian_day_epoch(), format='jd', scale='tcb').jyear - \
@@ -124,7 +124,7 @@ def test_Hip1_fit_to_hip44801():
     # generate fitter and parse intermediate data
     astro = Astrometry('Hip1', '44801', 'htof/test/data_for_tests/Hip1', central_epoch_ra=1991.25,
                        central_epoch_dec=1991.25, format='jyear', fit_degree=1, use_parallax=True,
-                       central_ra=cntr_ra, central_dec=cntr_dec, normed=False)
+                       central_ra=cntr_ra, central_dec=cntr_dec)
     chisq = np.sum(astro.data.residuals ** 2 / astro.data.along_scan_errs ** 2)
     # generate ra and dec for each observation.
     year_epochs = Time(astro.data.julian_day_epoch(), format='jd', scale='tcb').jyear - \
@@ -154,7 +154,7 @@ def test_Hip1_fit_to_hip70000():
     # generate fitter and parse intermediate data
     astro = Astrometry('Hip1', '70000', 'htof/test/data_for_tests/Hip1', central_epoch_ra=1991.25,
                        central_epoch_dec=1991.25, format='jyear', fit_degree=1, use_parallax=True,
-                       central_ra=cntr_ra, central_dec=cntr_dec, normed=False)
+                       central_ra=cntr_ra, central_dec=cntr_dec)
     chisq = np.sum(astro.data.residuals ** 2 / astro.data.along_scan_errs ** 2)
     # generate ra and dec for each observation.
     year_epochs = Time(astro.data.julian_day_epoch(), format='jd', scale='tcb').jyear - \
@@ -183,7 +183,7 @@ def test_Hip1_fit_to_hip27321_no_parallax():
     # generate fitter and parse intermediate data
     astro = Astrometry('Hip1', '27321', 'htof/test/data_for_tests/Hip1', central_epoch_ra=1991.25,
                        central_epoch_dec=1991.25, format='jyear', fit_degree=1,
-                       use_parallax=False, normed=False)
+                       use_parallax=False)
     chisq = np.sum(astro.data.residuals ** 2 / astro.data.along_scan_errs ** 2)
     # generate ra and dec for each observation.
     year_epochs = Time(astro.data.julian_day_epoch(), format='jd', scale='tcb').jyear - \
@@ -207,7 +207,7 @@ def test_optimal_central_epochs_forHip1_hip27321():
     # generate fitter and parse intermediate data
     astro = Astrometry('Hip1', '27321', 'htof/test/data_for_tests/Hip1', central_epoch_ra=1991.25,
                        central_epoch_dec=1991.25, format='jyear', fit_degree=1, use_parallax=True,
-                       central_ra=cntr_ra, central_dec=cntr_dec, normed=False)
+                       central_ra=cntr_ra, central_dec=cntr_dec)
     central_epoch = astro.optimal_central_epochs()
     central_epoch_ra, central_epoch_dec = central_epoch['ra'], central_epoch['dec']
     #print(central_epoch_ra, central_epoch_dec)
@@ -231,7 +231,7 @@ def test_optimal_central_epochs_forHip1_hip27321():
 def test_optimal_central_epochs_forHip1_hip27321_no_parallax():
     astro = Astrometry('Hip1', '27321', 'htof/test/data_for_tests/Hip1', central_epoch_ra=1991.25,
                        central_epoch_dec=1991.25, format='jyear', fit_degree=1,
-                       use_parallax=False, normed=False)
+                       use_parallax=False)
     central_epoch = astro.optimal_central_epochs()
     central_epoch_ra, central_epoch_dec = central_epoch['ra'], central_epoch['dec']
     #print(central_epoch_ra, central_epoch_dec)

--- a/htof/test/test_parse.py
+++ b/htof/test/test_parse.py
@@ -138,7 +138,6 @@ class TestHipparcosRereductionDVDBook:
         assert data.rejected_epochs == []
 
 
-
 class TestHipparcosRereductionJavaTool:
     test_data_directory = os.path.join(os.getcwd(), 'htof/test/data_for_tests/Hip21')
 

--- a/htof/validation/hip_roundoff_test.py
+++ b/htof/validation/hip_roundoff_test.py
@@ -9,7 +9,7 @@ import os
 
 
 def parse(datacsv, data, data_choice='MERGED', perturb=True):
-    if (data_choice is not 'NDAC') and (data_choice is not 'FAST') and (data_choice is not 'MERGED'):
+    if (data_choice != 'NDAC') and (data_choice != 'FAST') and (data_choice != 'MERGED'):
         raise ValueError('data choice has to be either NDAC or FAST or MERGED.')
     datacsv = data._fix_unnamed_column(datacsv)
     if perturb:

--- a/htof/validation/utils.py
+++ b/htof/validation/utils.py
@@ -28,7 +28,7 @@ def refit_hip_fromdata(data: DataParser, fit_degree, cntr_RA=Angle(0, unit='degr
     ra_resid = Angle(data.residuals.values * np.sin(data.scan_angle.values), unit='mas')
     dec_resid = Angle(data.residuals.values * np.cos(data.scan_angle.values), unit='mas')
     # instantiate fitter
-    fitter = AstrometricFitter(data.inverse_covariance_matrix, year_epochs, normed=False,
+    fitter = AstrometricFitter(data.inverse_covariance_matrix, year_epochs,
                                use_parallax=use_parallax, fit_degree=fit_degree,
                                parallactic_pertubations={'ra_plx': Angle(ra_motion, 'degree').mas,
                                                          'dec_plx': Angle(dec_motion, 'degree').mas})

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(name='htof',
       author='G. Mirek Brandt, Daniel Michalik',
-      version='0.3.4',
+      version='0.3.5',
       python_requires='>=3.6',
       packages=find_packages(),
       package_dir={'htof': 'htof'},


### PR DESCRIPTION
This PR removes the normed option, implements a warning when someone tries to add it to Astrometry() instantiation (this is for orvara), and fixes various syntax issues that led to a litany of warnings.